### PR TITLE
Local GitHub integration mock for development

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,5 +19,5 @@ POSTHOG_HOST=https://eu.posthog.com
 GITHUB_CRYPTLY_APP_ID=dontuseit
 GITHUB_CRYPTLY_APP_PRIVATE_KEY=dontuseit
 ALLOW_LOCAL_LOGIN=true
-# Stub GitHub App API; all users get the same demo installations and repositories.
+
 GITHUB_LOCAL_MOCK=true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,3 +19,5 @@ POSTHOG_HOST=https://eu.posthog.com
 GITHUB_CRYPTLY_APP_ID=dontuseit
 GITHUB_CRYPTLY_APP_PRIVATE_KEY=dontuseit
 ALLOW_LOCAL_LOGIN=true
+# Stub GitHub App API; all users get the same demo installations and repositories.
+GITHUB_LOCAL_MOCK=true

--- a/backend/src/external-connection/github/client/github-external-connection-client.service.ts
+++ b/backend/src/external-connection/github/client/github-external-connection-client.service.ts
@@ -1,6 +1,13 @@
 import { Injectable } from '@nestjs/common';
+import { getEnvConfig } from '../../../shared/config/env-config';
 import { GithubRepository } from './dto/github-repository.dto';
 import { GithubInstallationLiveData } from './dto/github-installation.dto';
+import {
+  isLocalGithubMockInstallationId,
+  LOCAL_GITHUB_MOCK_REPOSITORIES,
+  LOCAL_GITHUB_MOCK_REPOSITORY_KEY_ID,
+  LOCAL_GITHUB_MOCK_REPOSITORY_PUBLIC_KEY,
+} from './local-github-mock.constants';
 import { GithubApiFacadeService, GithubApiRepository } from './github-api-facade.service';
 
 export type GithubRepositoryKey = {
@@ -17,9 +24,17 @@ export type AccessTokenResponseDto = {
 export class GithubExternalConnectionClientService {
   constructor(private readonly githubApiFacadeService: GithubApiFacadeService) {}
 
+  private get isLocalGithubMock(): boolean {
+    return getEnvConfig().githubLocalMock;
+  }
+
   public async getRepositoriesAvailableForInstallation(
     installationId: number,
   ): Promise<GithubRepository[]> {
+    if (this.isLocalGithubMock && isLocalGithubMockInstallationId(installationId)) {
+      return [...LOCAL_GITHUB_MOCK_REPOSITORIES];
+    }
+
     const repositories =
       await this.githubApiFacadeService.getInstallationRepositories(installationId);
 
@@ -29,6 +44,14 @@ export class GithubExternalConnectionClientService {
   public async getInstallationByGithubInstallationId(
     installationId: number,
   ): Promise<GithubInstallationLiveData> {
+    if (this.isLocalGithubMock && isLocalGithubMockInstallationId(installationId)) {
+      return {
+        id: installationId,
+        avatar: 'https://avatars.githubusercontent.com/u/9919?s=64&v=4',
+        owner: 'cryptly-local',
+      };
+    }
+
     const installation = await this.githubApiFacadeService.getInstallationById(installationId);
 
     const account = installation.account || { avatar_url: '', login: '' };
@@ -48,12 +71,24 @@ export class GithubExternalConnectionClientService {
     repositoryId: number;
     githubInstallationId: number;
   }): Promise<GithubRepository> {
+    if (this.isLocalGithubMock && isLocalGithubMockInstallationId(params.githubInstallationId)) {
+      const repo = LOCAL_GITHUB_MOCK_REPOSITORIES.find((r) => r.id === params.repositoryId);
+      if (!repo) {
+        throw new Error(`Local mock: unknown repository id ${params.repositoryId}`);
+      }
+      return { ...repo };
+    }
+
     const repository = await this.githubApiFacadeService.getRepositoryById(params);
 
     return this.mapGithubApiRepository(repository);
   }
 
   public async getInstallationAccessToken(installationId: number): Promise<string> {
+    if (this.isLocalGithubMock && isLocalGithubMockInstallationId(installationId)) {
+      return 'local-github-mock-token';
+    }
+
     const accessToken =
       await this.githubApiFacadeService.createInstallationAccessToken(installationId);
 
@@ -65,6 +100,13 @@ export class GithubExternalConnectionClientService {
     githubInstallationId: number;
     repositoryName: string;
   }): Promise<GithubRepositoryKey> {
+    if (this.isLocalGithubMock && isLocalGithubMockInstallationId(params.githubInstallationId)) {
+      return {
+        keyId: LOCAL_GITHUB_MOCK_REPOSITORY_KEY_ID,
+        key: LOCAL_GITHUB_MOCK_REPOSITORY_PUBLIC_KEY,
+      };
+    }
+
     const publicKey = await this.githubApiFacadeService.getRepositoryPublicKey(params);
 
     return {

--- a/backend/src/external-connection/github/client/local-github-mock.constants.ts
+++ b/backend/src/external-connection/github/client/local-github-mock.constants.ts
@@ -1,0 +1,46 @@
+import { GithubRepository } from './dto/github-repository.dto';
+
+/** Synthetic GitHub App installation ids for local mock fall in this inclusive range. */
+export const LOCAL_GITHUB_MOCK_INSTALLATION_ID_MIN = 9_000_000;
+export const LOCAL_GITHUB_MOCK_INSTALLATION_ID_MAX = 9_999_999;
+
+export function isLocalGithubMockInstallationId(id: number): boolean {
+  return id >= LOCAL_GITHUB_MOCK_INSTALLATION_ID_MIN && id <= LOCAL_GITHUB_MOCK_INSTALLATION_ID_MAX;
+}
+
+export function localGithubMockInstallationIdForUser(userId: string): number {
+  let h = 0;
+  for (let i = 0; i < userId.length; i++) {
+    h = (h * 31 + userId.charCodeAt(i)) >>> 0;
+  }
+  const span = LOCAL_GITHUB_MOCK_INSTALLATION_ID_MAX - LOCAL_GITHUB_MOCK_INSTALLATION_ID_MIN + 1;
+  return LOCAL_GITHUB_MOCK_INSTALLATION_ID_MIN + (h % span);
+}
+
+/**
+ * Demo repositories returned for every user when local GitHub mock mode is on.
+ * Public key matches frontend SodiumCrypto.encrypt (libsodium crypto_box seal).
+ */
+export const LOCAL_GITHUB_MOCK_REPOSITORY_PUBLIC_KEY =
+  '4epbX4p6OIffO0wMxV55BUZ3osH7s7FBRiP+qdcghQs=';
+
+export const LOCAL_GITHUB_MOCK_REPOSITORY_KEY_ID = 'local-mock';
+
+export const LOCAL_GITHUB_MOCK_REPOSITORIES: GithubRepository[] = [
+  {
+    id: 900_001,
+    name: 'demo-repo',
+    owner: 'cryptly-local',
+    avatarUrl: 'https://avatars.githubusercontent.com/u/9919?s=64&v=4',
+    url: 'https://github.com/cryptly-local/demo-repo',
+    isPrivate: false,
+  },
+  {
+    id: 900_002,
+    name: 'another-app',
+    owner: 'cryptly-local',
+    avatarUrl: 'https://avatars.githubusercontent.com/u/9919?s=64&v=4',
+    url: 'https://github.com/cryptly-local/another-app',
+    isPrivate: true,
+  },
+];

--- a/backend/src/external-connection/github/core/github-external-connection-core.controller.ts
+++ b/backend/src/external-connection/github/core/github-external-connection-core.controller.ts
@@ -16,6 +16,7 @@ import { CurrentUserId } from '../../../auth/core/decorators/current-user-id.dec
 import { Public } from '../../../auth/core/decorators/is-public';
 import { ProjectMemberGuard } from '../../../project/core/guards/project-member.guard';
 import { ProjectReadService } from '../../../project/read/project-read.service';
+import { getEnvConfig } from '../../../shared/config/env-config';
 import { TokenResponse } from '../../../shared/responses/token.response';
 import { Role } from '../../../shared/types/role.enum';
 import { GithubRepositorySerialized } from '../client/dto/github-repository.dto';
@@ -104,10 +105,30 @@ export class GithubExternalConnectionCoreController {
   }
 
   @ApiResponse({ type: GithubInstallationSerialized, isArray: true })
+  @Get('users/me/external-connections/github/local-mock/bootstrap')
+  public async getLocalGithubMockBootstrap(
+    @CurrentUserId() currentUserId: string,
+  ): Promise<{ githubInstallationId: number }> {
+    if (!getEnvConfig().githubLocalMock) {
+      throw new ForbiddenException('Local GitHub mock is not enabled');
+    }
+
+    const installation = await this.installationWriteService.ensureLocalMockInstallationForUser(
+      currentUserId,
+    );
+
+    return { githubInstallationId: installation.githubInstallationId };
+  }
+
+  @ApiResponse({ type: GithubInstallationSerialized, isArray: true })
   @Get('users/me/external-connections/github/installations')
   public async getCurrentUserInstallations(
     @CurrentUserId() currentUserId: string,
   ): Promise<GithubInstallationSerialized[]> {
+    if (getEnvConfig().githubLocalMock) {
+      await this.installationWriteService.ensureLocalMockInstallationForUser(currentUserId);
+    }
+
     const installations = await this.installationReadService.findByUserId(currentUserId);
 
     const ghInstallations = await Promise.all(

--- a/backend/src/external-connection/github/write/github-installation-write.service.ts
+++ b/backend/src/external-connection/github/write/github-installation-write.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
+import { localGithubMockInstallationIdForUser } from '../client/local-github-mock.constants';
 import { GithubInstallationEntity } from '../core/entities/github-installation.entity';
 import { GithubInstallationNormalized } from '../core/entities/github-installation.interface';
 import { GithubInstallationSerializer } from '../core/entities/github-installation.serializer';
@@ -24,5 +25,25 @@ export class GithubInstallationWriteService {
 
   public async deleteByGithubInstallationId(githubInstallationId: number): Promise<void> {
     await this.model.deleteOne({ githubInstallationId });
+  }
+
+  /** Ensures a synthetic GitHub App installation exists for local mock mode (per-user stable id). */
+  public async ensureLocalMockInstallationForUser(userId: string): Promise<GithubInstallationNormalized> {
+    const githubInstallationId = localGithubMockInstallationIdForUser(userId);
+    let installation = await this.model
+      .findOne({
+        userId: new Types.ObjectId(userId),
+        githubInstallationId,
+      })
+      .exec();
+
+    if (!installation) {
+      installation = await this.model.create({
+        userId: new Types.ObjectId(userId),
+        githubInstallationId,
+      });
+    }
+
+    return GithubInstallationSerializer.normalize(installation);
   }
 }

--- a/backend/src/shared/config/env-config.ts
+++ b/backend/src/shared/config/env-config.ts
@@ -26,6 +26,8 @@ export interface EnvConfig {
     refreshTokenExpiresIn: string;
     allowLocalLogin: boolean;
   };
+  /** Stub GitHub App/API; serve fixed demo installations and repos for local dev. */
+  githubLocalMock: boolean;
   logdash: {
     apiKey: string;
   };
@@ -74,6 +76,7 @@ export const EnvConfigs: EnvConfigs = {
       refreshTokenExpiresIn: process.env.REFRESH_TOKEN_EXPIRES_IN || '30d',
       allowLocalLogin: process.env.ALLOW_LOCAL_LOGIN === 'true',
     },
+    githubLocalMock: process.env.GITHUB_LOCAL_MOCK === 'true',
     logdash: {
       apiKey: process.env.LOGDASH_API_KEY!,
     },
@@ -115,6 +118,7 @@ export const EnvConfigs: EnvConfigs = {
       refreshTokenExpiresIn: process.env.REFRESH_TOKEN_EXPIRES_IN || '30d',
       allowLocalLogin: process.env.ALLOW_LOCAL_LOGIN === 'true',
     },
+    githubLocalMock: process.env.GITHUB_LOCAL_MOCK === 'true',
     logdash: {
       apiKey: process.env.LOGDASH_API_KEY!,
     },

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,3 +4,5 @@ VITE_GOOGLE_CLIENT_ID=dontuseit
 VITE_GITHUB_CLIENT_ID=dontuseit
 VITE_POSTHOG_KEY=dontuseit
 VITE_ALLOW_LOCAL_LOGIN=true
+# When true (with backend GITHUB_LOCAL_MOCK), GitHub integrations use demo data and push is simulated.
+VITE_GITHUB_LOCAL_MOCK=true

--- a/frontend/src/components/dialogs/IntegrationsDialog.tsx
+++ b/frontend/src/components/dialogs/IntegrationsDialog.tsx
@@ -18,9 +18,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { WizardStepper } from "@/components/ui/wizard-stepper";
-import type { Integration } from "@/lib/api/integrations.api";
+import {
+  IntegrationsApi,
+  type Integration,
+} from "@/lib/api/integrations.api";
 import { ProjectMemberRole } from "@/lib/api/projects.api";
 import { useProjects } from "@/lib/hooks/useProjects";
+import { authLogic } from "@/lib/logics/authLogic";
 import { commonLogic } from "@/lib/logics/commonLogic";
 import {
   integrationsLogic,
@@ -39,6 +43,9 @@ import { useActions, useAsyncActions, useValues } from "kea";
 import { Wand2 } from "lucide-react";
 import posthog from "posthog-js";
 import { useEffect, useState, type ComponentType } from "react";
+
+const isGithubLocalMock =
+  import.meta.env.VITE_GITHUB_LOCAL_MOCK === "true";
 
 // ────────────────────────────────────────────────────────────
 // Integration row
@@ -299,6 +306,7 @@ function AddIntegrationWizard({
   onOpenChange: (open: boolean) => void;
 }) {
   const { activeProject } = useProjects();
+  const { jwtToken } = useValues(authLogic);
   const {
     installations,
     repositories,
@@ -330,8 +338,21 @@ function AddIntegrationWizard({
     setRepoSearch("");
   }, [selectedInstallationEntityId]);
 
-  const handleInstallApp = () => {
+  const handleInstallApp = async () => {
     setShouldReopenIntegrationsDialog(true);
+    if (isGithubLocalMock && jwtToken) {
+      try {
+        const { githubInstallationId } =
+          await IntegrationsApi.bootstrapLocalGithubMock(jwtToken);
+        await IntegrationsApi.createInstallation(jwtToken, {
+          githubInstallationId,
+        });
+        window.location.href = `${import.meta.env.VITE_APP_URL}/app/callbacks/integrations/github?installation_id=${githubInstallationId}&state=${encodeURIComponent(`"projectId=${activeProject?.id}"`)}`;
+      } catch (e) {
+        console.error(e);
+      }
+      return;
+    }
     window.location.href = `https://github.com/apps/cryptly-dev/installations/new?state="projectId=${activeProject?.id}"`;
   };
 

--- a/frontend/src/lib/api/integrations.api.ts
+++ b/frontend/src/lib/api/integrations.api.ts
@@ -58,7 +58,21 @@ export interface SecretDto {
   plainValue: string;
 }
 
+const isGithubLocalMock =
+  import.meta.env.VITE_GITHUB_LOCAL_MOCK === "true";
+
 export class IntegrationsApi {
+  /** Backend creates a synthetic installation when GITHUB_LOCAL_MOCK is on; used to fake the GitHub App install redirect. */
+  public static async bootstrapLocalGithubMock(
+    jwtToken: string
+  ): Promise<{ githubInstallationId: number }> {
+    const response = await axios.get<{ githubInstallationId: number }>(
+      `/users/me/external-connections/github/local-mock/bootstrap`,
+      { headers: { Authorization: `Bearer ${jwtToken}` } }
+    );
+    return response.data;
+  }
+
   public static async getRepositories(
     jwtToken: string,
     installationEntityId: string
@@ -190,6 +204,10 @@ export class IntegrationsApi {
     integrations: Integration[],
     content: string
   ): Promise<void> {
+    if (isGithubLocalMock) {
+      return;
+    }
+
     const secrets = dotenv.parse(content);
 
     await Promise.all(

--- a/frontend/src/lib/logics/projectLogic.ts
+++ b/frontend/src/lib/logics/projectLogic.ts
@@ -29,6 +29,9 @@ import { keyLogic } from "./keyLogic";
 import type { projectLogicType } from "./projectLogicType";
 import { projectsLogic } from "./projectsLogic";
 
+const isGithubLocalMock =
+  import.meta.env.VITE_GITHUB_LOCAL_MOCK === "true";
+
 export interface ProjectLogicProps {
   projectId: string;
 }
@@ -394,6 +397,11 @@ export const projectLogic = kea<projectLogicType>([
           values.integrations,
           values.inputValue
         );
+        if (isGithubLocalMock) {
+          toast.success("Pushed to GitHub (local mock — no secrets sent)", {
+            richColors: true,
+          });
+        }
       } finally {
         actions.setIsPushing(false);
       }

--- a/frontend/src/routes/app/callbacks/integrations/github.tsx
+++ b/frontend/src/routes/app/callbacks/integrations/github.tsx
@@ -5,6 +5,9 @@ import { useValues } from "kea";
 import posthog from "posthog-js";
 import { useEffect } from "react";
 
+const isGithubLocalMock =
+  import.meta.env.VITE_GITHUB_LOCAL_MOCK === "true";
+
 export const Route = createFileRoute("/app/callbacks/integrations/github")({
   component: RouteComponent,
 });
@@ -47,9 +50,11 @@ function RouteComponent() {
     projectId: string,
     installationId: string
   ) => {
-    await IntegrationsApi.createInstallation(jwtToken!, {
-      githubInstallationId: parseInt(installationId!),
-    });
+    if (!isGithubLocalMock) {
+      await IntegrationsApi.createInstallation(jwtToken!, {
+        githubInstallationId: parseInt(installationId!),
+      });
+    }
 
     navigate({
       to: "/app/project/$projectId",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables the full GitHub integrations UI and editor push flow when developing locally, without calling the real GitHub App API or pushing secrets to GitHub.

## Changes

- **Backend:** `GITHUB_LOCAL_MOCK=true` stubs `GithubExternalConnectionClientService` with fixed demo repositories (`cryptly-local/demo-repo`, `cryptly-local/another-app`), a per-user synthetic installation id in the 9,000,000–9,999,999 range, and a bootstrap GET route so the frontend can resolve the installation id before the OAuth-style redirect.
- **Frontend:** `VITE_GITHUB_LOCAL_MOCK=true` skips `pushSecrets` (no `api.github.com` calls) and shows a success toast; "Install GitHub App" runs the same callback URL flow against the local app instead of github.com.
- **Env:** Both flags are documented and default to `true` in `.env.example` files used by `make local`.

## How to verify

1. `make local` (or set the two env vars and run backend + frontend).
2. Log in with local login, create a project, open GitHub integrations, connect `demo-repo`.
3. In the editor, use Push — you should see the local-mock toast and no network traffic to GitHub.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4cc2ee4-8341-4a54-935e-a0ae244fd386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4cc2ee4-8341-4a54-935e-a0ae244fd386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

