### PR TITLE
feat: drag-and-drop image upload support to blog editor

### DIFF
--- a/frontend/src/components/blog/BlogEditorPage.tsx
+++ b/frontend/src/components/blog/BlogEditorPage.tsx
@@ -146,6 +146,31 @@ export function BlogEditorPage({ mode, slug }: BlogEditorPageProps) {
     [uploadPastedImage]
   );
 
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLTextAreaElement>) => {
+      if (Array.from(event.dataTransfer.types).includes("Files")) {
+        event.preventDefault();
+      }
+    },
+    []
+  );
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLTextAreaElement>) => {
+      const files = event.dataTransfer?.files;
+      if (!files || files.length === 0) return;
+      const images = Array.from(files).filter((file) =>
+        file.type.startsWith("image/")
+      );
+      if (images.length === 0) return;
+      event.preventDefault();
+      for (const file of images) {
+        void uploadPastedImage(file);
+      }
+    },
+    [uploadPastedImage]
+  );
+
   const handleCoverImagePaste = useCallback(
     (event: React.ClipboardEvent<HTMLInputElement>) => {
       const items = event.clipboardData?.items;
@@ -376,7 +401,7 @@ export function BlogEditorPage({ mode, slug }: BlogEditorPageProps) {
             <div className="flex items-center gap-4">
               <span className="inline-flex items-center gap-1.5">
                 <ImageUp className="w-3.5 h-3.5" />
-                Paste images directly
+                Paste or drop images
               </span>
               <span>{wordCount} words</span>
             </div>
@@ -386,6 +411,8 @@ export function BlogEditorPage({ mode, slug }: BlogEditorPageProps) {
             value={content}
             onChange={(e) => setContent(e.target.value)}
             onPaste={handlePaste}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
             spellCheck={false}
             className="flex-1 w-full resize-none bg-black px-6 py-6 text-[15px] leading-7 font-mono text-neutral-200 placeholder:text-neutral-700 focus:outline-none"
             placeholder="# Start typing…"


### PR DESCRIPTION
## Summary
Added drag-and-drop functionality to the blog editor's content textarea, allowing users to upload images by dragging and dropping them directly into the editor alongside the existing paste functionality.

## Key Changes
- **New `handleDragOver` handler**: Prevents default behavior when files are dragged over the textarea
- **New `handleDrop` handler**: Processes dropped files, filters for image types, and uploads them using the existing `uploadPastedImage` function
- **Updated UI label**: Changed hint text from "Paste images directly" to "Paste or drop images" to reflect the new capability
- **Connected handlers**: Attached `onDragOver` and `onDrop` event listeners to the content textarea

## Implementation Details
- The drag-and-drop implementation reuses the existing `uploadPastedImage` function, maintaining consistency with paste-based uploads
- Image filtering is performed to only accept files with `image/*` MIME types
- The implementation follows the same callback pattern as existing event handlers with proper dependency arrays

https://claude.ai/code/session_01BWWcs9ePw5FMFtcmSC4e2w