### PR TITLE
feat: add image resizing and improve blog editor UX

### DIFF
--- a/frontend/src/components/blog/BlogEditorPage.tsx
+++ b/frontend/src/components/blog/BlogEditorPage.tsx
@@ -28,6 +28,9 @@ Write in markdown on the left. Preview renders live on the right.
 
 Paste an image from clipboard — it will be uploaded and a markdown link inserted automatically.
 
+Resize images by adding a size after a pipe in the alt text:
+\`![caption|small](url)\` — also \`medium\`, \`large\`, \`full\`, or pixel widths like \`![caption|400](url)\` and \`![caption|400x250](url)\`.
+
 ## Some ideas
 
 - Launches
@@ -229,11 +232,24 @@ export function BlogEditorPage({ mode, slug }: BlogEditorPageProps) {
       if (mode === "create") {
         const created = await BlogApi.create(jwtToken, payload);
         toast.success("Post published");
-        navigate({ to: "/blog/$slug", params: { slug: created.slug } });
+        setPostId(created.id);
+        setSlugInput(created.slug);
+        navigate({
+          to: "/blog/edit/$slug",
+          params: { slug: created.slug },
+          replace: true,
+        });
       } else if (postId) {
         const updated = await BlogApi.update(jwtToken, postId, payload);
         toast.success("Post updated");
-        navigate({ to: "/blog/$slug", params: { slug: updated.slug } });
+        if (updated.slug !== slug) {
+          setSlugInput(updated.slug);
+          navigate({
+            to: "/blog/edit/$slug",
+            params: { slug: updated.slug },
+            replace: true,
+          });
+        }
       }
     } catch (err) {
       const message =
@@ -245,7 +261,7 @@ export function BlogEditorPage({ mode, slug }: BlogEditorPageProps) {
     } finally {
       setSaving(false);
     }
-  }, [jwtToken, title, content, excerpt, coverImageUrl, slugInput, releaseDate, mode, postId, navigate]);
+  }, [jwtToken, title, content, excerpt, coverImageUrl, slugInput, releaseDate, mode, postId, slug, navigate]);
 
   const handleDelete = useCallback(async () => {
     if (!jwtToken || !postId) return;
@@ -266,6 +282,20 @@ export function BlogEditorPage({ mode, slug }: BlogEditorPageProps) {
       setDeleting(false);
     }
   }, [jwtToken, postId, navigate]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === "s") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!saving && !deleting) {
+          void handleSave();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [handleSave, saving, deleting]);
 
   const wordCount = useMemo(
     () => content.trim().split(/\s+/).filter(Boolean).length,

--- a/frontend/src/components/blog/BlogMarkdown.tsx
+++ b/frontend/src/components/blog/BlogMarkdown.tsx
@@ -1,9 +1,48 @@
+import type { CSSProperties } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 interface BlogMarkdownProps {
   content: string;
   className?: string;
+}
+
+const NAMED_WIDTHS: Record<string, string> = {
+  small: "240px",
+  medium: "480px",
+  large: "720px",
+  full: "100%",
+};
+
+function parseImageSpec(alt: string | undefined): {
+  alt: string;
+  width?: string;
+  height?: string;
+  isFullWidth: boolean;
+} {
+  if (!alt) return { alt: "", isFullWidth: true };
+  const pipe = alt.lastIndexOf("|");
+  if (pipe === -1) return { alt, isFullWidth: true };
+  const spec = alt.slice(pipe + 1).trim().toLowerCase();
+  const cleanAlt = alt.slice(0, pipe).trim();
+  if (!spec) return { alt: cleanAlt, isFullWidth: true };
+
+  if (spec in NAMED_WIDTHS) {
+    const width = NAMED_WIDTHS[spec];
+    return { alt: cleanAlt, width, isFullWidth: spec === "full" };
+  }
+
+  const dims = spec.match(/^(\d+)(?:x(\d+))?$/);
+  if (dims) {
+    return {
+      alt: cleanAlt,
+      width: `${dims[1]}px`,
+      height: dims[2] ? `${dims[2]}px` : undefined,
+      isFullWidth: false,
+    };
+  }
+
+  return { alt, isFullWidth: true };
 }
 
 export function BlogMarkdown({ content, className }: BlogMarkdownProps) {
@@ -94,13 +133,23 @@ export function BlogMarkdown({ content, className }: BlogMarkdownProps) {
             </pre>
           ),
           hr: () => <hr className="my-10 border-neutral-800" />,
-          img: ({ src, alt }) => (
-            <img
-              src={src}
-              alt={alt}
-              className="my-8 w-full rounded-xl border border-neutral-800 shadow-xl"
-            />
-          ),
+          img: ({ src, alt }) => {
+            const parsed = parseImageSpec(alt);
+            const style: CSSProperties = {};
+            if (parsed.width) style.width = parsed.width;
+            if (parsed.height) style.height = parsed.height;
+            if (parsed.width && !parsed.isFullWidth) style.maxWidth = "100%";
+            return (
+              <img
+                src={src}
+                alt={parsed.alt}
+                style={style}
+                className={`my-8 rounded-xl border border-neutral-800 shadow-xl${
+                  parsed.isFullWidth ? " w-full" : ""
+                }`}
+              />
+            );
+          },
           table: ({ children }) => (
             <div className="my-6 overflow-x-auto rounded-lg border border-neutral-800">
               <table className="w-full text-sm border-collapse">{children}</table>


### PR DESCRIPTION
## Summary
This PR enhances the blog editor with image resizing capabilities and improves the post creation/editing workflow.

## Key Changes

**Image Resizing Feature**
- Added `parseImageSpec()` function to parse image sizing directives from alt text using pipe syntax
- Supports named sizes: `small` (240px), `medium` (480px), `large` (720px), `full` (100%)
- Supports pixel dimensions: `![caption|400](url)` or `![caption|400x250](url)`
- Updated `BlogMarkdown` image renderer to apply parsed width/height styles
- Added documentation in the editor help text explaining the new syntax

**Blog Editor Improvements**
- After creating a new post, now navigates to the edit page instead of the view page, keeping the user in edit mode
- When updating a post with a slug change, navigates to the new slug's edit page
- Added keyboard shortcut support: Cmd+S (Mac) or Ctrl+S (Windows/Linux) to save posts
- Fixed dependency array in `handleSave` callback to include `slug` parameter

## Implementation Details
- Image sizing is parsed from the alt text after a pipe character (e.g., `![My Image|medium](url)`)
- Non-full-width images get `maxWidth: 100%` applied to prevent overflow while maintaining aspect ratio
- The keyboard shortcut listener is properly cleaned up on component unmount
- Navigation uses `replace: true` to prevent back button issues after post creation

https://claude.ai/code/session_01AeSREkn86tecDBTkRCA7j5