### PR TITLE
feat: blog image position utilities

### DIFF
--- a/frontend/src/components/blog/BlogEditorPage.tsx
+++ b/frontend/src/components/blog/BlogEditorPage.tsx
@@ -28,8 +28,9 @@ Write in markdown on the left. Preview renders live on the right.
 
 Paste an image from clipboard — it will be uploaded and a markdown link inserted automatically.
 
-Resize images by adding a size after a pipe in the alt text:
+Style images by adding modifiers after a pipe in the alt text:
 \`![caption|small](url)\` — also \`medium\`, \`large\`, \`full\`, or pixel widths like \`![caption|400](url)\` and \`![caption|400x250](url)\`.
+Combine with space-separated modifiers: \`center\` to center, \`flat\` to remove rounded corners — e.g. \`![caption|400 center flat](url)\`.
 
 ## Some ideas
 

--- a/frontend/src/components/blog/BlogMarkdown.tsx
+++ b/frontend/src/components/blog/BlogMarkdown.tsx
@@ -19,30 +19,58 @@ function parseImageSpec(alt: string | undefined): {
   width?: string;
   height?: string;
   isFullWidth: boolean;
+  center: boolean;
+  flat: boolean;
 } {
-  if (!alt) return { alt: "", isFullWidth: true };
-  const pipe = alt.lastIndexOf("|");
-  if (pipe === -1) return { alt, isFullWidth: true };
-  const spec = alt.slice(pipe + 1).trim().toLowerCase();
+  const empty = { alt: "", isFullWidth: true, center: false, flat: false };
+  if (!alt) return empty;
+  const pipe = alt.indexOf("|");
+  if (pipe === -1)
+    return { ...empty, alt, isFullWidth: true };
   const cleanAlt = alt.slice(0, pipe).trim();
-  if (!spec) return { alt: cleanAlt, isFullWidth: true };
+  const tokens = alt
+    .slice(pipe + 1)
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (tokens.length === 0)
+    return { ...empty, alt: cleanAlt };
 
-  if (spec in NAMED_WIDTHS) {
-    const width = NAMED_WIDTHS[spec];
-    return { alt: cleanAlt, width, isFullWidth: spec === "full" };
+  let width: string | undefined;
+  let height: string | undefined;
+  let isFullWidth = true;
+  let center = false;
+  let flat = false;
+  let unknown = false;
+
+  for (const token of tokens) {
+    if (token in NAMED_WIDTHS) {
+      width = NAMED_WIDTHS[token];
+      isFullWidth = token === "full";
+      continue;
+    }
+    const dims = token.match(/^(\d+)(?:x(\d+))?$/);
+    if (dims) {
+      width = `${dims[1]}px`;
+      height = dims[2] ? `${dims[2]}px` : undefined;
+      isFullWidth = false;
+      continue;
+    }
+    if (token === "center") {
+      center = true;
+      continue;
+    }
+    if (token === "flat" || token === "sharp" || token === "square") {
+      flat = true;
+      continue;
+    }
+    unknown = true;
   }
 
-  const dims = spec.match(/^(\d+)(?:x(\d+))?$/);
-  if (dims) {
-    return {
-      alt: cleanAlt,
-      width: `${dims[1]}px`,
-      height: dims[2] ? `${dims[2]}px` : undefined,
-      isFullWidth: false,
-    };
+  if (unknown && width === undefined && !center && !flat) {
+    return { ...empty, alt, isFullWidth: true };
   }
-
-  return { alt, isFullWidth: true };
+  return { alt: cleanAlt, width, height, isFullWidth, center, flat };
 }
 
 export function BlogMarkdown({ content, className }: BlogMarkdownProps) {
@@ -139,15 +167,19 @@ export function BlogMarkdown({ content, className }: BlogMarkdownProps) {
             if (parsed.width) style.width = parsed.width;
             if (parsed.height) style.height = parsed.height;
             if (parsed.width && !parsed.isFullWidth) style.maxWidth = "100%";
+            const classes = [
+              "my-8",
+              "border",
+              "border-neutral-800",
+              "shadow-xl",
+              parsed.flat ? "rounded-none" : "rounded-xl",
+              parsed.isFullWidth ? "w-full" : "",
+              parsed.center ? "block mx-auto" : "",
+            ]
+              .filter(Boolean)
+              .join(" ");
             return (
-              <img
-                src={src}
-                alt={parsed.alt}
-                style={style}
-                className={`my-8 rounded-xl border border-neutral-800 shadow-xl${
-                  parsed.isFullWidth ? " w-full" : ""
-                }`}
-              />
+              <img src={src} alt={parsed.alt} style={style} className={classes} />
             );
           },
           table: ({ children }) => (


### PR DESCRIPTION
## Summary

Three quality-of-life improvements to the blog editor.

### Image sizing utilities (`BlogMarkdown.tsx`)
Markdown image alt text now accepts a spec after a pipe, with space-separated modifiers:

- Named widths: `small` (240px), `medium` (480px), `large` (720px), `full` (100%)
- Pixel widths: `400`, `400x250`
- `center` — horizontally centers the image (`block mx-auto`)
- `flat` (or `sharp` / `square`) — removes the default rounded corners

Examples:
- `![caption|small](url)`
- `![caption|400x250](url)`
- `![photo|400 center](url)`
- `![logo|small flat center](url)`

If no spec is given, behavior is unchanged (full width, rounded). The spec portion is stripped from the rendered alt text.

### Save stays in edit mode (`BlogEditorPage.tsx`)
- Edit-mode save no longer navigates to the public post view — it just shows the toast and stays on the editor. If the slug changed, the URL is updated via `replace`.
- Create-mode now redirects to `/blog/edit/<slug>` instead of `/blog/<slug>`, so a freshly published post drops the user back into editing.

### Cmd/Ctrl+S keyboard shortcut (`BlogEditorPage.tsx`)
- Document-level keydown listener calls `handleSave` and prevents the browser's default save dialog. No-ops while a save or delete is already in flight.

## Test plan

- [ ] In create mode: Cmd+S triggers save; on success, URL changes to `/blog/edit/<slug>` and editor stays open
- [ ] In edit mode: Cmd+S triggers save; URL doesn't change unless the slug was edited
- [ ] `![alt|small](url)` renders at 240px width
- [ ] `![alt|400x250](url)` renders at 400×250
- [ ] `![alt|center](url)` is horizontally centered
- [ ] `![alt|flat](url)` has no rounded corners
- [ ] `![alt|400 center flat](url)` combines all three
- [ ] `![alt](url)` (no spec) still renders full-width with rounded corners (unchanged)

https://claude.ai/code/session_01AeSREkn86tecDBTkRCA7j5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeSREkn86tecDBTkRCA7j5)_